### PR TITLE
git-fixup: Learn -i interactive mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,8 +40,7 @@ $ git commit            # Create commits
 $ git set -g            # Push and create remote branch
                         # .. after review comments, do fixes
 $ git add -p            # Add fixes
-$ git fixup-targets     # List fixup targets
-$ git fixup cafeha5h    # Create commits
+$ git fixup -i          # List fixup targets and select target
                         #   repeat as needed
 $ git autosquash        # Apply fixups
 $ git conflicting edit  # During the rebase, if there are conflicts quickly

--- a/bin/git-fixup
+++ b/bin/git-fixup
@@ -1,3 +1,39 @@
 #!/bin/bash
 
-git commit --fixup "$@"
+if [[ $# -eq 0 ]]; then
+  echo "Usage git fixup [-i]/[<ref>]"
+  exit 1
+fi
+
+if [[ "${1}" == "-i" ]]; then
+  targets=$(git fixup-targets)
+
+  IFS=$'\n' read -rd '' -a lines <<<"${targets}"
+  if [[ "${#lines[@]}" -eq 0 ]]; then
+    echo "No fixup targets available"
+    exit 0
+  fi
+
+  for ((i=0; i < ${#lines[@]}; i++)); do
+    echo "[$((i+1))]: ${lines[${i}]}"
+  done
+
+  echo "Select target: [q/0-9+]"
+  read -p "> " selected_target
+
+  if [[ "${selected_target}" == "q" ]]; then
+    exit 0
+  fi
+  if [[ -z "${selected_target}" ]] \
+     || [[ "${selected_target}" -lt 1 ]]\
+     || [[ "${selected_target}" -gt "${#lines[@]}" ]]; then
+    echo "Invalid option" >&2
+    exit 1
+  fi
+
+  target_hash=$(cut -f 1 -d " " <<<"${lines[selected_target - 1]}")
+  git commit --fixup "${target_hash}"
+  exit 0
+fi
+
+git commit --fixup "${1}"

--- a/docs/git-fixup.md
+++ b/docs/git-fixup.md
@@ -2,3 +2,17 @@
 
 This tool is effectively an alias for `git commit --fixup`, and lessens to
 amount of typing necessary when working with a rebase flow.
+
+Alternatively it can be used in interactive mode by specifying the option `-i`.
+This will list all fixup-targets, and let you numerically choose the target.
+
+```sh
+$ git fixup -i
+[1]: b9e0e78 (HEAD -> master) Here's a commit
+[2]: 41f2c83 fix(a-thing): Fix the a thing
+[3]: a32b218 More A
+Select target: [q/0-9+]
+> 2
+[master 5ccafd2] fixup! fix(a-thing): Fix the a thing
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+````


### PR DESCRIPTION
Almost always the target to fixup can be found by the git-fixup-targets. Having to select the target by copying the hash and then pasting it into a git-fixup command is more tedious than it really has to be.

This change ensures that the git-fixup script understand the -i flag which will list all the fixup-targets with associated numbers, it then output a prompt for the user. If the user enters the corresponding number a fixup commit for the target will be created.