### PR TITLE
git-get: Learn interactive (-i)

### DIFF
--- a/bin/git-get
+++ b/bin/git-get
@@ -35,13 +35,6 @@ do
   esac
 done
 
-if [[ -z "${BRANCH}" ]]
-then
-  echo "No branch specified" >&2
-  exit 1
-fi
-
-
 if [[ "${FORCE}" != "true" ]]
 then
   UNCOMMITTED_CHANGES=$(git status --porcelain=v2 | grep -e "^[12] ")
@@ -59,5 +52,10 @@ then
   fi
 fi
 
+if [[ -z "${BRANCH}" ]]
+then
+  echo "No branch specified" >&2
+  exit 1
+fi
 
 git reset --hard "refs/remotes/${REMOTE}/${BRANCH_PREFIX}${BRANCH}"

--- a/bin/git-get
+++ b/bin/git-get
@@ -15,12 +15,17 @@ fi
 
 FORCE=false
 BRANCH=""
+INTERACTIVE=false
 
 while [[ $# -gt 0 ]]
 do
   case ${1} in
     -f|--force)
     FORCE=true
+    shift
+    ;;
+    -i)
+    INTERACTIVE=true
     shift
     ;;
     *)
@@ -50,6 +55,37 @@ then
     echo "No remote branch tracking HEAD, this would lose data. Use --force/-f to override" >&2
     exit 3
   fi
+fi
+
+if [[ "${INTERACTIVE}" == true ]]
+then
+  BRANCHES=$(git branches)
+  echo "${BRANCHES}"
+
+  IFS=$'\n' read -rd '' -a LINES <<<"${BRANCHES}"
+  if [[ "${#LINES[@]}" -eq 0 ]]; then
+    echo "No matching remote branches"
+    exit 0
+  fi
+
+  for ((i=0; i < ${#LINES[@]}; i++)); do
+    echo "[$((i+1))]: ${LINES[${i}]}"
+  done
+
+  echo "Select branch: [q/0-9+]"
+  read -p "> " SELECTED_BRANCH
+
+  if [[ "${SELECTED_BRANCH}" == "q" ]]; then
+    exit 0
+  fi
+  if [[ -z "${SELECTED_BRANCH}" ]] \
+     || [[ "${SELECTED_BRANCH}" -lt 1 ]]\
+     || [[ "${SELECTED_BRANCH}" -gt "${#LINES[@]}" ]]; then
+    echo "Invalid option" >&2
+    exit 1
+  fi
+
+  BRANCH=${LINES[SELECTED_BRANCH - 1]}
 fi
 
 if [[ -z "${BRANCH}" ]]


### PR DESCRIPTION
Very often when switching branches I find myself doing the pattern of
selecting among the available branches with git-branches only to
copy and paste the branch I care about into git-get.

By utilizing a similar mechanic as git-fixup to select a target, this
process can be simplified.