### PR TITLE
git-fixup-targets: Use relative paths to identify targets

### DIFF
--- a/bin/git-fixup-targets
+++ b/bin/git-fixup-targets
@@ -14,7 +14,7 @@ if [[ -n "${first_merge}" ]]; then
   fi
 fi
 
-changes=$(git diff --staged --name-only)
+changes=$(git diff --staged --name-only --relative)
 
 if [[ -z "${changes}" ]]; then
   echo "Nothing matched" >&2


### PR DESCRIPTION
Git log with a path filter interprets these paths as being relative to the current directory.  If the current working directory is not in the root of the repo, then this means that means that we previously failed to correctly identify the fixup targets.